### PR TITLE
Match more liberally on URL segments

### DIFF
--- a/src/list-tabs.js
+++ b/src/list-tabs.js
@@ -36,7 +36,7 @@ function run(args) {
         windowIndex: w,
         tabIndex: t,
         arg: `${w},${t},${url}`,
-        match: `${title} ${matchUrl}`,
+        match: `${title} ${matchUrl.replaceAll(/[^\w]/g, " ")}`,
       };
     }
   }


### PR DESCRIPTION
Items only match if the search string prefix-matches a word in the `match` property. This can be inconvenient for, say, a tab where Spotify is playing. We want to type "spotify" and have the tab match, but the `match` property looks like "Song Name . Artist open.spotify.com/user/<username>". Hence, we'll get a match if we type "open.spotify", but not if we type "spotify".

This change splits `matchUrl` into many elements for more liberal keyword matching. Tabs will now match any subdomain, the root domain, or any element of the path or query.